### PR TITLE
Limited Pydantic version <1.8 (currently broken).

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ include_package_data = True
 python_requires = >=3.7
 packages = find_namespace:
 install_requires = 
-	pydantic>=1.0,<2.0  # minimum version may be higher - please submit a PR!
+	pydantic>=1.0,<1.8,<2.0  # minimum version may be higher - please submit a PR!
 	semver  # 2 or 3 should both work
 	deprecated
 test_require = 


### PR DESCRIPTION
This should set 0.5.2 to properly specify compatibility.