### PR TITLE
Added yaml(description=) option to output commented yaml

### DIFF
--- a/pydantic_yaml/mixin.py
+++ b/pydantic_yaml/mixin.py
@@ -195,10 +195,25 @@ class YamlModelMixin(metaclass=ModelMetaclass):
 
     @staticmethod
     def add_inline_descriptions(data, model): 
+        """add_inline_descriptions recursively checks the pydantic structure
+        for comments that can be added to the resulting yaml
+
+        Parameters
+        ----------
+        data :
+            Ruaml round-trip yaml.dumps structure
+        model :
+            The pydantic model which contains the description information
+        """
+        from ruamel.yaml.comments import CommentedBase
+
+        if isinstance(data,list):
+            for item, info in zip(data,model):
+                YamlModelMixin.add_inline_descriptions(item,info)
+
         if not hasattr(model, "__fields__"):
             return
         fields = model.__fields__
-        from ruamel.yaml.comments import CommentedBase
         if isinstance(data,CommentedBase) and isinstance(data, dict) :
             for k, v in data.items():
                 if not k in fields.keys():
@@ -208,6 +223,8 @@ class YamlModelMixin(metaclass=ModelMetaclass):
                     data.yaml_add_eol_comment(description, k)
                 if hasattr(model,k):
                     YamlModelMixin.add_inline_descriptions(v,getattr(model,k))
+
+        
 
 
     @no_type_check

--- a/pydantic_yaml/mixin.py
+++ b/pydantic_yaml/mixin.py
@@ -160,7 +160,16 @@ class YamlModelMixin(metaclass=ModelMetaclass):
                 " This may not work as expected. If so, please create a GitHub issue:"
                 " https://github.com/NowanIlfideme/pydantic-yaml/issues/new"
             )
+
         cfg = cast(YamlModelMixinConfig, self.__config__)
+        dump = cfg.yaml_dumps(
+            data,
+            default_flow_style=default_flow_style,
+            default_style=default_style,
+            encoding=encoding,
+            indent=indent,
+            **kwargs,
+        )
         
         if descriptions:
             if not 'ruamel' in __yaml_lib__:
@@ -182,16 +191,10 @@ class YamlModelMixin(metaclass=ModelMetaclass):
             self.add_inline_descriptions(data,self)
             dump = StringIO()
             yaml.dump(data,dump)
-            return dump.getvalue()
+            dump = dump.getvalue()
 
-        return cfg.yaml_dumps(
-            data,
-            default_flow_style=default_flow_style,
-            default_style=default_style,
-            encoding=encoding,
-            indent=indent,
-            **kwargs,
-        )
+        return dump
+
 
     @staticmethod
     def add_inline_descriptions(data, model): 

--- a/pydantic_yaml/test/test_file_comments.py
+++ b/pydantic_yaml/test/test_file_comments.py
@@ -1,0 +1,52 @@
+"""Tests for file comments."""
+
+# type: ignore
+
+from json.decoder import JSONDecodeError
+from pathlib import Path
+from typing import no_type_check
+
+import pytest
+
+
+@no_type_check
+def test_file_comments(tmpdir: str):
+    """Test file IO with temporary files (tmpdir is a pytest fixture)."""
+
+    from pydantic import BaseModel, Field
+    from pydantic_yaml import YamlModel, YamlModelMixin, YamlStrEnum
+
+    class MyEnum(YamlStrEnum):
+        a = "a"
+        b = "b"
+
+    class MyModel(YamlModel):
+        x: int = Field(42, description="This is an important description")
+        e: MyEnum = Field(MyEnum.a, description="doubletest")
+
+    class TestBase(BaseModel):
+        tag: str = "my tag"
+
+    class MyOtherModel(YamlModelMixin, TestBase):
+        sub: MyModel = Field(None, description="Mymodel description")
+
+    m1 = MyModel(x=2, e="b")
+    m2 = MyOtherModel(sub=m1)
+
+    base_dir: Path = Path(tmpdir).resolve()
+
+    for (m, M) in zip([m1, m2], [MyModel, MyOtherModel]):
+        with (base_dir / "mdl.yaml").open(mode="w") as f:
+            f.write(m.yaml(descriptions = True))
+        with (base_dir / "mdl.json").open(mode="w") as f:
+            f.write(m.json())
+        assert M.parse_file(base_dir / "mdl.yaml") == m
+        assert M.parse_file(base_dir / "mdl.json") == m
+        assert M.parse_file(base_dir / "mdl.yaml", content_type=None) == m
+        assert M.parse_file(base_dir / "mdl.json", content_type=None) == m
+
+        with pytest.raises(JSONDecodeError):
+            M.parse_file(base_dir / "mdl.yaml", content_type="application/json")
+        # This works because JSON is a subset of YAML :)
+        mx = M.parse_file(base_dir / "mdl.json", content_type="application/yaml")
+        assert mx == m

--- a/pydantic_yaml/test/test_file_comments.py
+++ b/pydantic_yaml/test/test_file_comments.py
@@ -50,3 +50,10 @@ def test_file_comments(tmpdir: str):
         # This works because JSON is a subset of YAML :)
         mx = M.parse_file(base_dir / "mdl.json", content_type="application/yaml")
         assert mx == m
+
+        with open(base_dir / "mdl.yaml", "r") as f:
+            text = f.read()
+            assert('This is an important description' in text)
+            assert('doubletest' in text)
+            assert('Mymodel description' in text)
+

--- a/pydantic_yaml/test/test_file_comments.py
+++ b/pydantic_yaml/test/test_file_comments.py
@@ -4,7 +4,7 @@
 
 from json.decoder import JSONDecodeError
 from pathlib import Path
-from typing import no_type_check
+from typing import no_type_check, List
 
 import pytest
 
@@ -29,13 +29,13 @@ def test_file_comments(tmpdir: str):
 
     class MyOtherModel(YamlModelMixin, TestBase):
         sub: MyModel = Field(None, description="Mymodel description")
+        sublist: List[MyModel] = [MyModel()]
 
-    m1 = MyModel(x=2, e="b")
-    m2 = MyOtherModel(sub=m1)
+    m2 = MyOtherModel(sub=MyModel(x="41"), sublist=[MyModel(),MyModel(x="43",e="b")])
 
     base_dir: Path = Path(tmpdir).resolve()
 
-    for (m, M) in zip([m1, m2], [MyModel, MyOtherModel]):
+    for (m, M) in zip([m2], [MyOtherModel]):
         with (base_dir / "mdl.yaml").open(mode="w") as f:
             f.write(m.yaml(descriptions = True))
         with (base_dir / "mdl.json").open(mode="w") as f:

--- a/pydantic_yaml/test/test_file_comments.py
+++ b/pydantic_yaml/test/test_file_comments.py
@@ -5,6 +5,7 @@
 from json.decoder import JSONDecodeError
 from pathlib import Path
 from typing import no_type_check, List
+from pydantic_yaml.compat.yaml_lib import __yaml_lib__
 
 import pytest
 
@@ -12,6 +13,10 @@ import pytest
 @no_type_check
 def test_file_comments(tmpdir: str):
     """Test file IO with temporary files (tmpdir is a pytest fixture)."""
+
+    if 'ruamel-new' not in __yaml_lib__:
+        pytest.skip("comments only work with ruamel-new")
+        return
 
     from pydantic import BaseModel, Field
     from pydantic_yaml import YamlModel, YamlModelMixin, YamlStrEnum


### PR DESCRIPTION
Ls,

This is a pull request to add support for output of commented yaml. It's a feature we want to use in our project to generate better config files for scientists with explanations within the config file itsself.

An issue is that this will only work with ruamel (pyyaml has no support for comments), and probably the ad-hoc round-trip ruamel parser/dumper could be moved to its own file.

Please let me know your thoughts on this.
