### PR TITLE
rm error silencing, fail fast if no yaml lib exists

### DIFF
--- a/pydantic_yaml/__init__.py
+++ b/pydantic_yaml/__init__.py
@@ -2,33 +2,33 @@
 
 from .version import __version__
 
-try:
-    __all__ = [
-        "__version__",
-        "SemVer",
-        "yaml",
-        "VersionedYamlModel",
-        "YamlEnum",  # deprecated class
-        "YamlInt",
-        "YamlIntEnum",
-        "YamlModel",
-        "YamlModelMixin",
-        "YamlModelMixinConfig",
-        "YamlStr",
-        "YamlStrEnum",
-    ]
-    from .main import (
-        SemVer,
-        VersionedYamlModel,
-        YamlEnum,
-        YamlInt,
-        YamlIntEnum,
-        YamlModel,
-        YamlModelMixin,
-        YamlModelMixinConfig,
-        YamlStr,
-        YamlStrEnum,
-        yaml,
-    )
-except Exception:
-    pass
+from pydantic_yaml.compat.yaml_lib import __yaml_lib__ as _
+
+
+__all__ = [
+    "__version__",
+    "SemVer",
+    "yaml",
+    "VersionedYamlModel",
+    "YamlEnum",  # deprecated class
+    "YamlInt",
+    "YamlIntEnum",
+    "YamlModel",
+    "YamlModelMixin",
+    "YamlModelMixinConfig",
+    "YamlStr",
+    "YamlStrEnum",
+]
+from .main import (
+    SemVer,
+    VersionedYamlModel,
+    YamlEnum,
+    YamlInt,
+    YamlIntEnum,
+    YamlModel,
+    YamlModelMixin,
+    YamlModelMixinConfig,
+    YamlStr,
+    YamlStrEnum,
+    yaml,
+)


### PR DESCRIPTION
Fixes https://github.com/NowanIlfideme/pydantic-yaml/issues/29

- drop global error silencing on import / during init eval
- fail fast if required dependencies are missing
