### PR TITLE
Making semver optional

### DIFF
--- a/pydantic_yaml/main.py
+++ b/pydantic_yaml/main.py
@@ -21,10 +21,15 @@ from .compat.old_enums import YamlEnum
 from .compat.hacks import inject_all as _inject_yaml_hacks
 from .compat.types import YamlInt, YamlIntEnum, YamlStr, YamlStrEnum
 from .compat.yaml_lib import yaml, yaml_safe_dump, yaml_safe_load
-from .ext.semver import SemVer
-from .ext.versioned_model import VersionedYamlModel
 from .mixin import YamlModelMixin, YamlModelMixinConfig
 from .model import YamlModel
 from .version import __version__
+
+try:
+    from .ext.semver import SemVer
+    from .ext.versioned_model import VersionedYamlModel
+except:
+    __all__.remove("SemVer")
+    __all__.remove("VersionedYamlModel")
 
 _inject_yaml_hacks()

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,8 +39,7 @@ include_package_data = True
 python_requires = >=3.7
 packages = find_namespace:
 install_requires = 
-	pydantic>=1.8,<2.0
-	semver>=2.13.0,<4  # Versions 2 or 3 should both work
+	pydantic>=1.8,<2.0	
 	deprecated~=1.2.5
 	types-Deprecated
 test_require = 
@@ -55,6 +54,7 @@ pyyaml =
 	pyyaml
 	types-PyYAML
 ruamel = ruamel.yaml>=0.15,<0.18  # new API starting from 0.15, but old is still available
+semver = semver>=2.13.0,<4  # Versions 2 or 3 should both work
 dev = 
 	black
 	flake8


### PR DESCRIPTION
As in the [this issue](https://github.com/NowanIlfideme/pydantic-yaml/issues/38), usage of semver package can be made optional. This PR has a small change on two files that does not change any functionality. It would be great if you could release this as a minor version too.