### PR TITLE
Added YAML dumping options, including custom class.

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,11 +75,23 @@ class MyModel(BaseModel):
         allow_mutation = False
 ```
 
-A separate configuration for YAML specifically will be added later.
+You can control some YAML-specfic options via the keyword options:
 
 ```python
-# TODO
+to_yaml_str(model, indent=4)  # Makes it wider
+to_yaml_str(model, map_indent=9, sequence_indent=7)  # ... you monster.
 ```
+
+You can additionally pass your own `YAML` instance:
+
+```python
+from ruamel.yaml import YAML
+my_writer = YAML(typ="safe")
+my_writer.default_flow_style = True
+to_yaml_file("foo.yaml", model, custom_yaml_writer=my_writer)
+```
+
+A separate configuration for YAML specifically will be added later, likely in v2.
 
 ## Breaking Changes for `pydantic-yaml` V1
 
@@ -96,4 +108,4 @@ However, this will be availble only for `pydantic<2`.
 ### Versioned Models
 
 This functionality has been removed, as it's questionably useful for most users.
-There is an [example in the docs](docs/versioned.md) that's available.
+There is an [example in the docs](versioned.md) that's available.

--- a/README.md
+++ b/README.md
@@ -57,6 +57,24 @@ assert m1 == m3
 
 ```
 
+With Pydantic v2, you can also dump dataclasses:
+
+```python
+from pydantic import RootModel
+from pydantic.dataclasses import dataclass
+from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic_yaml import to_yaml_str
+
+assert PYDANTIC_VERSION >= "2"
+
+@dataclass
+class YourType:
+    foo: str = "bar"
+
+obj = YourType(foo="wuz")
+assert to_yaml_str(RootModel[YourType](obj)) == 'foo: wuz\n'
+```
+
 ## Configuration
 
 Currently we use the JSON dumping of Pydantic to perform most of the magic.

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,11 +75,23 @@ class MyModel(BaseModel):
         allow_mutation = False
 ```
 
-A separate configuration for YAML specifically will be added later.
+You can control some YAML-specfic options via the keyword options:
 
 ```python
-# TODO
+to_yaml_str(model, indent=4)  # Makes it wider
+to_yaml_str(model, map_indent=9, sequence_indent=7)  # ... you monster.
 ```
+
+You can additionally pass your own `YAML` instance:
+
+```python
+from ruamel.yaml import YAML
+my_writer = YAML(typ="safe")
+my_writer.default_flow_style = True
+to_yaml_file("foo.yaml", model, custom_yaml_writer=my_writer)
+```
+
+A separate configuration for YAML specifically will be added later, likely in v2.
 
 ## Breaking Changes for `pydantic-yaml` V1
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -57,6 +57,24 @@ assert m1 == m3
 
 ```
 
+With Pydantic v2, you can also dump dataclasses:
+
+```python
+from pydantic import RootModel
+from pydantic.dataclasses import dataclass
+from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic_yaml import to_yaml_str
+
+assert PYDANTIC_VERSION >= "2"
+
+@dataclass
+class YourType:
+    foo: str = "bar"
+
+obj = YourType(foo="wuz")
+assert to_yaml_str(RootModel[YourType](obj)) == 'foo: wuz\n'
+```
+
 ## Configuration
 
 Currently we use the JSON dumping of Pydantic to perform most of the magic.

--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -85,7 +85,7 @@ def _write_yaml_model(
 def to_yaml_str(
     model: BaseModel,
     *,
-    default_flow_style: Optional[bool] = True,
+    default_flow_style: Optional[bool] = False,
     indent: Optional[int] = None,
     map_indent: Optional[int] = None,
     sequence_indent: Optional[int] = None,
@@ -138,7 +138,7 @@ def to_yaml_file(
     file: Union[Path, str, IOBase],
     model: BaseModel,
     *,
-    default_flow_style: Optional[bool] = True,
+    default_flow_style: Optional[bool] = False,
     indent: Optional[int] = True,
     map_indent: Optional[int] = None,
     sequence_indent: Optional[int] = None,

--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -85,7 +85,7 @@ def _write_yaml_model(
 def to_yaml_str(
     model: BaseModel,
     *,
-    default_flow_style: Optional[bool] = None,
+    default_flow_style: Optional[bool] = True,
     indent: Optional[int] = None,
     map_indent: Optional[int] = None,
     sequence_indent: Optional[int] = None,
@@ -138,7 +138,7 @@ def to_yaml_file(
     file: Union[Path, str, IOBase],
     model: BaseModel,
     *,
-    default_flow_style: Optional[bool] = None,
+    default_flow_style: Optional[bool] = True,
     indent: Optional[int] = True,
     map_indent: Optional[int] = None,
     sequence_indent: Optional[int] = None,
@@ -154,6 +154,16 @@ def to_yaml_file(
         The file path or stream to write to.
     model : BaseModel
         The model to write.
+    default_flow_style : bool
+        Whether to use "flow style" (more human-readable).
+        https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
+    indent : None or int
+        General indent value. Leave as None for the default.
+    map_indent, sequence_indent, sequence_dash_offset : None or int
+        More specific indent values.
+    custom_yaml_writer : None or YAML
+        An instance of ruamel.yaml.YAML (or a subclass) to use as the writer.
+        The above options will be set on it, if given.
     json_kwargs : Any
         Keyword arguments to pass `model.json()`.
 

--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -4,12 +4,14 @@ See Also
 --------
 Roundtrip comments with ruamel.yaml
     https://yaml.readthedocs.io/en/latest/detail.html#round-trip-including-comments
+    Currently, it's not possible to round-trip comments in `pydantic-yaml`.
+    If you need to keep comments, you'll have to have parallel updating and validation.
 """
 
 import json
 from io import StringIO, IOBase
 from pathlib import Path
-from typing import Any, Union
+from typing import Any, Optional, Union
 
 import pydantic
 from ruamel.yaml import YAML
@@ -23,7 +25,18 @@ def _chk_model(model: Any) -> BaseModel:
     raise TypeError("We can currently only write `pydantic.BaseModel`, " f"but recieved: {model!r}")
 
 
-def _write_yaml_model(stream: IOBase, model: BaseModel, default_flow_style: bool, **kwargs) -> None:
+def _write_yaml_model(
+    stream: IOBase,
+    model: BaseModel,
+    *,
+    default_flow_style: Optional[bool] = None,
+    indent: Optional[int] = None,
+    map_indent: Optional[int] = None,
+    sequence_indent: Optional[int] = None,
+    sequence_dash_offset: Optional[int] = None,
+    custom_yaml_writer: Optional[YAML] = None,
+    **json_kwargs,
+) -> None:
     """Write YAML model to the stream object.
 
     This uses JSON dumping as an intermediary.
@@ -33,34 +46,71 @@ def _write_yaml_model(stream: IOBase, model: BaseModel, default_flow_style: bool
     stream : IOBase
         The stream to write to.
     model : BaseModel
-        The model to convert.
-    kwargs : Any
+        The model to write.
+    default_flow_style : bool
+        Whether to use "flow style" (more human-readable).
+        https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
+    indent : None or int
+        General indent value. Leave as None for the default.
+    map_indent, sequence_indent, sequence_dash_offset : None or int
+        More specific indent values.
+    custom_yaml_writer : None or YAML
+        An instance of ruamel.yaml.YAML (or a subclass) to use as the writer.
+        The above options will be set on it, if given.
+    json_kwargs : Any
         Keyword arguments to pass `model.json()`.
-        FIXME: Add explicit arguments.
     """
     model = _chk_model(model)
     if pydantic.version.VERSION < "2":
-        json_val = model.json(**kwargs)  # type: ignore
+        json_val = model.json(**json_kwargs)  # type: ignore
     else:
-        json_val = model.model_dump_json(**kwargs)  # type: ignore
+        json_val = model.model_dump_json(**json_kwargs)  # type: ignore
     val = json.loads(json_val)
-    writer = YAML(typ="safe", pure=True)
-    writer.default_flow_style = default_flow_style
-    # TODO: Configure writer further
-    # writer.indent(...) for example
+    # Allow setting custom writer
+    if custom_yaml_writer is None:
+        writer = YAML(typ="safe", pure=True)
+    elif isinstance(custom_yaml_writer, YAML):
+        writer = custom_yaml_writer
+    else:
+        raise TypeError(f"Please pass a YAML instance or subclass. Got {custom_yaml_writer!r}")
+    # Set options
+    if default_flow_style is not None:
+        writer.default_flow_style = default_flow_style
+    writer.indent(mapping=indent, sequence=indent, offset=indent)
+    writer.indent(mapping=map_indent, sequence=sequence_indent, offset=sequence_dash_offset)
+    # TODO: Configure writer further?
     writer.dump(val, stream)
 
 
-def to_yaml_str(model: BaseModel, default_flow_style: bool = True, **kwargs) -> str:
+def to_yaml_str(
+    model: BaseModel,
+    *,
+    default_flow_style: Optional[bool] = None,
+    indent: Optional[int] = None,
+    map_indent: Optional[int] = None,
+    sequence_indent: Optional[int] = None,
+    sequence_dash_offset: Optional[int] = None,
+    custom_yaml_writer: Optional[YAML] = None,
+    **json_kwargs,
+) -> str:
     """Generate a YAML string representation of the model.
 
     Parameters
     ----------
     model : BaseModel
         The model to convert.
-    kwargs : Any
+    default_flow_style : bool
+        Whether to use "flow style" (more human-readable).
+        https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
+    indent : None or int
+        General indent value. Leave as None for the default.
+    map_indent, sequence_indent, sequence_dash_offset : None or int
+        More specific indent values.
+    custom_yaml_writer : None or YAML
+        An instance of ruamel.yaml.YAML (or a subclass) to use as the writer.
+        The above options will be set on it, if given.
+    json_kwargs : Any
         Keyword arguments to pass `model.json()`.
-        FIXME: Add explicit arguments.
 
     Notes
     -----
@@ -69,13 +119,32 @@ def to_yaml_str(model: BaseModel, default_flow_style: bool = True, **kwargs) -> 
     """
     model = _chk_model(model)
     stream = StringIO()
-    _write_yaml_model(stream, model, default_flow_style, **kwargs)
+    _write_yaml_model(
+        stream,
+        model,
+        default_flow_style=default_flow_style,
+        indent=indent,
+        map_indent=map_indent,
+        sequence_indent=sequence_indent,
+        sequence_dash_offset=sequence_dash_offset,
+        custom_yaml_writer=custom_yaml_writer,
+        **json_kwargs,
+    )
     stream.seek(0)
     return stream.read()
 
 
 def to_yaml_file(
-    file: Union[Path, str, IOBase], model: BaseModel, default_flow_style: bool = True, **kwargs
+    file: Union[Path, str, IOBase],
+    model: BaseModel,
+    *,
+    default_flow_style: Optional[bool] = None,
+    indent: Optional[int] = True,
+    map_indent: Optional[int] = None,
+    sequence_indent: Optional[int] = None,
+    sequence_dash_offset: Optional[int] = None,
+    custom_yaml_writer: Optional[YAML] = None,
+    **json_kwargs,
 ) -> None:
     """Write a YAML file representation of the model.
 
@@ -84,10 +153,9 @@ def to_yaml_file(
     file : Path or str or IOBase
         The file path or stream to write to.
     model : BaseModel
-        The model to convert.
-    kwargs : Any
+        The model to write.
+    json_kwargs : Any
         Keyword arguments to pass `model.json()`.
-        FIXME: Add explicit arguments.
 
     Notes
     -----
@@ -96,7 +164,17 @@ def to_yaml_file(
     """
     model = _chk_model(model)
     if isinstance(file, IOBase):
-        _write_yaml_model(file, model, default_flow_style, **kwargs)
+        _write_yaml_model(
+            file,
+            model,
+            default_flow_style=default_flow_style,
+            indent=indent,
+            map_indent=map_indent,
+            sequence_indent=sequence_indent,
+            sequence_dash_offset=sequence_dash_offset,
+            custom_yaml_writer=custom_yaml_writer,
+            **json_kwargs,
+        )
         return
 
     if isinstance(file, str):
@@ -107,4 +185,4 @@ def to_yaml_file(
         raise TypeError(f"Expected Path, str, or stream, but got {file!r}")
 
     with file.open(mode="w") as f:
-        _write_yaml_model(f, model, **kwargs)
+        _write_yaml_model(f, model, **json_kwargs)

--- a/src/test/test_dump_custom.py
+++ b/src/test/test_dump_custom.py
@@ -1,0 +1,25 @@
+"""Test custom dumping behavior."""
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_yaml import to_yaml_str
+from pydantic_yaml.examples.base_models import HasEnums
+from pydantic_yaml.examples.common import MyIntEnum, MyStrEnum
+
+has_enums = HasEnums(opts=MyStrEnum.option1, vals=[MyIntEnum.v1, MyIntEnum.v2])
+
+
+@pytest.mark.parametrize(
+    ["mdl", "kwargs", "expected"],
+    [
+        [has_enums, dict(default_flow_style=False), "opts: option1\nvals:\n- 1\n- 2\n"],
+        [has_enums, dict(default_flow_style=True), "{opts: option1, vals: [1, 2]}\n"],
+        [has_enums, dict(indent=4), "opts: option1\nvals:\n    - 1\n    - 2\n"],
+        [has_enums, dict(indent=6, map_indent=2), "opts: option1\nvals:\n      - 1\n      - 2\n"],
+    ],
+)
+def test_dump_kwargs(mdl: BaseModel, kwargs: dict, expected: str):
+    """Test dumping keyword arguments."""
+    res = to_yaml_str(mdl, **kwargs)
+    assert res == expected

--- a/src/test/test_v2_dataclass.py
+++ b/src/test/test_v2_dataclass.py
@@ -1,0 +1,23 @@
+"""Test for dataclasses in Pydantic v2."""
+
+import pytest
+
+from pydantic.version import VERSION as PYDANTIC_VERSION
+from pydantic.dataclasses import dataclass
+from pydantic_yaml import to_yaml_str
+
+
+@dataclass
+class ExampleDataclass:
+    """Example dataclass."""
+
+    foo: str = "bar"
+
+
+@pytest.mark.skipif(PYDANTIC_VERSION < "2", reason="Only supported for Pydantic v2.")
+def test_pydantic_v2_dataclass():
+    """Test doc-explained Dataclass support in Pydantic V2."""
+    from pydantic import RootModel
+
+    obj = ExampleDataclass(foo="wuz")
+    assert to_yaml_str(RootModel[ExampleDataclass](obj)) == "foo: wuz\n"


### PR DESCRIPTION
Added ability to specfy custom ruamel.yaml options, including custom writer.

Closes #71. Also could be useful for users who want to extend #28 and #14.