### PR TITLE
Add support for parsing specific section of yml file

### DIFF
--- a/src/pydantic_yaml/__init__.py
+++ b/src/pydantic_yaml/__init__.py
@@ -4,6 +4,7 @@ __all__ = [
     # New API
     "__version__",
     "parse_yaml_file_as",
+    "parse_yaml_raw_section_as",
     "parse_yaml_raw_as",
     "to_yaml_file",
     "to_yaml_str",
@@ -19,5 +20,8 @@ __all__ = [
 
 from .deprecated.types import YamlInt, YamlIntEnum, YamlStr, YamlStrEnum
 from .dumper import to_yaml_file, to_yaml_str
-from .loader import parse_yaml_file_as, parse_yaml_raw_as
+from .loader import (
+    parse_yaml_file_as,
+    parse_yaml_raw_as,
+    parse_yaml_raw_section_as)
 from .version import __version__

--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -23,7 +23,7 @@ def _chk_model(model: Any) -> BaseModel:
     raise TypeError(f"We can currently only write `pydantic.BaseModel`, but recieved: {model!r}")
 
 
-def _write_yaml_model(stream: IOBase, model: BaseModel, **kwargs) -> None:
+def _write_yaml_model(stream: IOBase, model: BaseModel, default_flow_style: bool, **kwargs) -> None:
     """Write YAML model to the stream object.
 
     This uses JSON dumping as an intermediary.
@@ -44,13 +44,13 @@ def _write_yaml_model(stream: IOBase, model: BaseModel, **kwargs) -> None:
         json_val = model.model_dump_json(**kwargs)  # type: ignore
     val = json.loads(json_val)
     writer = YAML(typ="safe", pure=True)
-    # TODO: Configure writer
-    # writer.default_flow_style = True or False or smth like that
+    writer.default_flow_style = default_flow_style
+    # TODO: Configure writer further
     # writer.indent(...) for example
     writer.dump(val, stream)
 
 
-def to_yaml_str(model: BaseModel, **kwargs) -> str:
+def to_yaml_str(model: BaseModel, default_flow_style: bool = True, **kwargs) -> str:
     """Generate a YAML string representation of the model.
 
     Parameters
@@ -67,12 +67,12 @@ def to_yaml_str(model: BaseModel, **kwargs) -> str:
     """
     model = _chk_model(model)
     stream = StringIO()
-    _write_yaml_model(stream, model, **kwargs)
+    _write_yaml_model(stream, model, default_flow_style, **kwargs)
     stream.seek(0)
     return stream.read()
 
 
-def to_yaml_file(file: Union[Path, str, IOBase], model: BaseModel, **kwargs) -> None:
+def to_yaml_file(file: Union[Path, str, IOBase], model: BaseModel, default_flow_style: bool = True, **kwargs) -> None:
     """Write a YAML file representation of the model.
 
     Parameters
@@ -91,7 +91,7 @@ def to_yaml_file(file: Union[Path, str, IOBase], model: BaseModel, **kwargs) -> 
     """
     model = _chk_model(model)
     if isinstance(file, IOBase):
-        _write_yaml_model(file, model, **kwargs)
+        _write_yaml_model(file, model, default_flow_style,**kwargs)
         return
 
     if isinstance(file, str):

--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -153,12 +153,6 @@ def to_yaml_file(
     file : Path or str or IOBase
         The file path or stream to write to.
     model : BaseModel
-<<<<<<< HEAD
-        The model to convert.
-    kwargs : Any
-        Keyword arguments to pass `model.json()`.
-        FIXME: Add explicit arguments.
-=======
         The model to write.
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).

--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -20,10 +20,13 @@ def _chk_model(model: Any) -> BaseModel:
     """Ensure the model passed is a Pydantic model."""
     if isinstance(model, BaseModel):
         return model
-    raise TypeError(f"We can currently only write `pydantic.BaseModel`, but recieved: {model!r}")
+    raise TypeError(("We can currently only write `pydantic.BaseModel`, "
+                     f"but recieved: {model!r}"))
 
 
-def _write_yaml_model(stream: IOBase, model: BaseModel, default_flow_style: bool, **kwargs) -> None:
+def _write_yaml_model(stream: IOBase,
+                      model: BaseModel,
+                      default_flow_style: bool, **kwargs) -> None:
     """Write YAML model to the stream object.
 
     This uses JSON dumping as an intermediary.
@@ -35,7 +38,8 @@ def _write_yaml_model(stream: IOBase, model: BaseModel, default_flow_style: bool
     model : BaseModel
         The model to convert.
     kwargs : Any
-        Keyword arguments to pass `model.json()`. FIXME: Add explicit arguments.
+        Keyword arguments to pass `model.json()`.
+        FIXME: Add explicit arguments.
     """
     model = _chk_model(model)
     if pydantic.version.VERSION < "2":
@@ -50,7 +54,8 @@ def _write_yaml_model(stream: IOBase, model: BaseModel, default_flow_style: bool
     writer.dump(val, stream)
 
 
-def to_yaml_str(model: BaseModel, default_flow_style: bool = True, **kwargs) -> str:
+def to_yaml_str(model: BaseModel,
+                default_flow_style: bool = True, **kwargs) -> str:
     """Generate a YAML string representation of the model.
 
     Parameters
@@ -58,7 +63,8 @@ def to_yaml_str(model: BaseModel, default_flow_style: bool = True, **kwargs) -> 
     model : BaseModel
         The model to convert.
     kwargs : Any
-        Keyword arguments to pass `model.json()`. FIXME: Add explicit arguments.
+        Keyword arguments to pass `model.json()`.
+        FIXME: Add explicit arguments.
 
     Notes
     -----
@@ -72,7 +78,11 @@ def to_yaml_str(model: BaseModel, default_flow_style: bool = True, **kwargs) -> 
     return stream.read()
 
 
-def to_yaml_file(file: Union[Path, str, IOBase], model: BaseModel, default_flow_style: bool = True, **kwargs) -> None:
+def to_yaml_file(
+    file: Union[Path, str, IOBase],
+    model: BaseModel,
+    default_flow_style: bool = True, **kwargs
+) -> None:
     """Write a YAML file representation of the model.
 
     Parameters
@@ -82,7 +92,8 @@ def to_yaml_file(file: Union[Path, str, IOBase], model: BaseModel, default_flow_
     model : BaseModel
         The model to convert.
     kwargs : Any
-        Keyword arguments to pass `model.json()`. FIXME: Add explicit arguments.
+        Keyword arguments to pass `model.json()`.
+        FIXME: Add explicit arguments.
 
     Notes
     -----
@@ -91,7 +102,7 @@ def to_yaml_file(file: Union[Path, str, IOBase], model: BaseModel, default_flow_
     """
     model = _chk_model(model)
     if isinstance(file, IOBase):
-        _write_yaml_model(file, model, default_flow_style,**kwargs)
+        _write_yaml_model(file, model, default_flow_style, **kwargs)
         return
 
     if isinstance(file, str):

--- a/src/pydantic_yaml/loader.py
+++ b/src/pydantic_yaml/loader.py
@@ -47,7 +47,7 @@ def parse_yaml_file_as(model_type: Type[T], file: Union[Path, str, IOBase]) -> T
     model_type : Type[BaseModel]
         The resulting model type.
     file : Path or str or IOBase
-        The file path or stream to write to.
+        The file path or stream to read from.
     """
     # Short-circuit
     if isinstance(file, IOBase):

--- a/src/test/test_basic.py
+++ b/src/test/test_basic.py
@@ -7,7 +7,13 @@ import pydantic
 import pytest
 from pydantic import BaseModel
 
-from pydantic_yaml import parse_yaml_file_as, parse_yaml_raw_as, to_yaml_str, to_yaml_file
+from pydantic_yaml import (
+    parse_yaml_file_as,
+    parse_yaml_raw_as,
+    parse_yaml_raw_section_as,
+    to_yaml_str,
+    to_yaml_file,
+)
 
 from pydantic_yaml.examples.base_models import (
     A,
@@ -53,6 +59,15 @@ def test_load_rt_simple_files(model_type: Type[BaseModel], fn: str):
 def test_write_simple_model(model: BaseModel):
     """Test output of simple models."""
     to_yaml_str(model)  # TODO: Check output vs expected?
+
+
+def test_load_model_from_section():
+    yml = """
+A:
+    a: 'test'
+"""
+    a = parse_yaml_raw_section_as("A", A, yml)
+    assert a.a == "test"
 
 
 @pytest.mark.xfail(pydantic.VERSION >= "2", reason="Pydantic v2 is stricter for Bytes types.")


### PR DESCRIPTION
Adds `parse_yaml_raw_section_as` function, which allows for selectively picking out a section from a YAML file and only parsing that as a given type. This is useful if you want to include settings for several different objects into a single file and keep things neat by the use of sections.

For example, supposing the two models:
```
class Chair(BaseModel):
    height: float
    back: bool

class Table(BaseModel):
    heigh: float
    seats: int
```

this PR adds the ability to write this single config.yaml

```
Chair:
    height: 0.6
    back: false

Table:
    height: 1.1
    seats: 3
```
and having the loading logic of the host application able to pick out settings for the Table and Chair objects according to its own needs. 

This is significantly more flexible than having to define a host object containing a `table` and `chair` property of types `Chair` and `Table`, as in this suggested version section names can be chosen freely by.

I have still not installed ruff, many apologies if I've messed up some formatting when I split out some common functionality into helper functions.  