### PR TITLE
Hotfix: Fix indenting when dumping to the file.

### DIFF
--- a/src/pydantic_yaml/dumper.py
+++ b/src/pydantic_yaml/dumper.py
@@ -139,7 +139,7 @@ def to_yaml_file(
     model: BaseModel,
     *,
     default_flow_style: Optional[bool] = False,
-    indent: Optional[int] = True,
+    indent: Optional[int] = None,
     map_indent: Optional[int] = None,
     sequence_indent: Optional[int] = None,
     sequence_dash_offset: Optional[int] = None,


### PR DESCRIPTION
Well I'm not sure what exactly happened but here's the fix.

Strange that ruamel.yaml accepted that value, but in general this gives yet another reason to eventually make a custom dumper...