### PR TITLE
deps: drop importlib_metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 requires = [
     "setuptools >= 61.0.0",
     "setuptools-scm[toml]>=6.2",
-    "importlib_metadata>=4.2.0",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -27,7 +26,6 @@ classifiers = [
 dependencies = [
     "pydantic>=1.8",               # including pydantic>=2.0.0!
     "ruamel.yaml>=0.16.0,<0.19.0", # recommended ~=0.17.21
-    "importlib_metadata",
     "typing_extensions>=4.5.0",
 ]
 urls = { github = "https://github.com/NowanIlfideme/pydantic-yaml", docs = "https://pydantic-yaml.readthedocs.io/en/latest/" }
@@ -99,12 +97,4 @@ ignore_missing_imports = true
 
 [[tool.mypy.overrides]]
 module = 'setuptools_scm.*'
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = 'importlib.metadata'
-ignore_missing_imports = true
-
-[[tool.mypy.overrides]]
-module = 'importlib_metadata'
 ignore_missing_imports = true

--- a/src/pydantic_yaml/version.py
+++ b/src/pydantic_yaml/version.py
@@ -2,24 +2,18 @@
 
 __all__ = ["__version__"]
 
-from typing import no_type_check
 
-
-@no_type_check
 def __get_version() -> str:
     try:
         from setuptools_scm import get_version  # noqa
 
         vv = get_version(root="../..", relative_to=__file__)
     except Exception:
-        try:
-            import importlib.metadata as _im  # noqa
-        except ImportError:
-            import importlib_metadata as _im  # noqa
+        import importlib.metadata as _im
 
         try:
             vv = _im.version("pydantic_yaml")
-        except _im.PackageNotFoundError:  # noqa
+        except _im.PackageNotFoundError:
             vv = "0.0.0"
     return vv
 


### PR DESCRIPTION
This is now included in all supported python versions, starting with 3.8: https://docs.python.org/3/library/importlib.metadata.html
