### PR TITLE
Fix TypeError issue when parse List of objects

### DIFF
--- a/src/pydantic_yaml/_internals/v2.py
+++ b/src/pydantic_yaml/_internals/v2.py
@@ -235,7 +235,7 @@ def parse_yaml_raw_as(model_type: Type[T], raw: Union[str, bytes, IOBase]) -> T:
         raise TypeError(f"Expected str, bytes or IO, but got {raw!r}")
     reader = YAML(typ="safe", pure=True)  # YAML 1.2 support
     objects = reader.load(stream)
-    if issubclass(model_type, BaseModelV1):
+    if isinstance(model_type, type) and issubclass(model_type, BaseModelV1):
         return parse_obj_as(model_type, objects)  # type:ignore
     else:
         ta = TypeAdapter(model_type)  # type: ignore


### PR DESCRIPTION
When try to parse List of objects fails with:

TypeError: issubclass() arg 1 must be a class

Check if model_type is a type before issubclass solve the issue.