### PR TITLE
Update requirements due to end-of-life of Python 3.8 and upcoming EOL for 3.9

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -15,8 +15,8 @@ jobs:
       fail-fast: true  # we want CI to immediately fail for releases
       matrix:
         python-version:
-          - "3.8"
-          - "3.11"
+          - "3.10"
+          - "3.13"
         deps:
           - dev
           - dev,docs
@@ -66,7 +66,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.8"
+          python-version: "3.10"
       - name: Install build/upload dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -26,8 +26,8 @@ jobs:
           - "2.11.5"
         lib-ruamel:
           - "NOTSET"
-          - "0.16.0"
-          - "0.17.21"
+          - "0.17.40"
+          - "0.18.11"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -16,13 +16,13 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          - "3.13"
+          - "3.12"
         deps:
           - dev
           - dev,docs
         lib-pydantic:
           - "1.10.22"  # last supported versions of Pydantic v1
-          - "2.0.3"
+          - "2.5.0"  # first version to support python 3.12
           - "2.11.5"
         lib-ruamel:
           - "NOTSET"

--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -21,10 +21,9 @@ jobs:
           - dev
           - dev,docs
         lib-pydantic:
-          - "1.8.2"
-          - "1.9.0"
-          - "1.10.0"
-          - "2.0.3" # test with pydantic 2
+          - "1.10.22"  # last supported versions of Pydantic v1
+          - "2.0.3"
+          - "2.11.5"
         lib-ruamel:
           - "NOTSET"
           - "0.16.0"

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -18,8 +18,8 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-          - "3.8"
-          - "3.11"
+          - "3.10"
+          - "3.13"
         deps:
           - dev
           - dev,docs

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -19,13 +19,13 @@ jobs:
       matrix:
         python-version:
           - "3.10"
-          - "3.13"
+          - "3.12"
         deps:
           - dev
           - dev,docs
         lib-pydantic:
           - "1.10.22"  # last supported versions of Pydantic v1
-          - "2.0.3"
+          - "2.5.0"  # first version to support python 3.12
           - "2.11.5"
         lib-ruamel:
           - "NOTSET"

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -29,8 +29,8 @@ jobs:
           - "2.11.5"
         lib-ruamel:
           - "NOTSET"
-          - "0.16.0"
-          - "0.17.21"
+          - "0.17.40"
+          - "0.18.11"
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -24,10 +24,9 @@ jobs:
           - dev
           - dev,docs
         lib-pydantic:
-          - "1.8.2"
-          - "1.9.0"
-          - "1.10.0"
-          - "2.0.3" # test with pydantic 2
+          - "1.10.22"  # last supported versions of Pydantic v1
+          - "2.0.3"
+          - "2.11.5"
         lib-ruamel:
           - "NOTSET"
           - "0.16.0"

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 # Configuration for pre-commit hooks, see: https://pre-commit.com/
 default_language_version:
-  python: python3.8
+  python: python3.10
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.3.0

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -10,7 +10,7 @@ mkdocs:
   fail_on_warning: false
 
 python:
-  version: "3.8"
+  version: "3.10"
   install:
     # We are using "pip" to install
     - method: pip

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,12 +9,11 @@ mkdocs:
   configuration: mkdocs.yml
   fail_on_warning: false
 
-python:
-  version: "3.10"
-  install:
+build:
+  os: "ubuntu-24.04"
+  tools:
     # We are using "pip" to install
-    - method: pip
-      path: .
-      extra_requirements:
-        - docs
-        - pyyaml
+    python: "mambaforge-22.9"
+
+conda:
+  environment: environment.yml

--- a/env-v1.yml
+++ b/env-v1.yml
@@ -3,7 +3,7 @@ name: pyd-v1-yaml
 channels:
   - conda-forge
 dependencies:
-  - python=3.8 # docs need 3.8
+  - python=3.10 # docs need 3.10
   - pip
   - pip:
       - -e ".[dev,docs]"

--- a/environment.yml
+++ b/environment.yml
@@ -3,7 +3,7 @@ name: pyd-yaml
 channels:
   - conda-forge
 dependencies:
-  - python=3.8 # docs need 3.8
+  - python=3.10 # docs need 3.10
   - pip
   - pip:
       - -e ".[dev,docs]"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "pydantic_yaml"
 description = "Adds some YAML functionality to the excellent `pydantic` library."
 readme = "README.md"
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 dynamic = ["version"]
 keywords = ["pydantic", "yaml"]
 license = { file = "LICENSE" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=1.8",               # including pydantic>=2.0.0!
-    "ruamel.yaml>=0.16.0,<0.19.0", # recommended ~=0.17.21
+    "ruamel.yaml>=0.17.0,<0.19.0", # recommended ~=0.17.21
     "typing_extensions>=4.5.0",
 ]
 urls = { github = "https://github.com/NowanIlfideme/pydantic-yaml", docs = "https://pydantic-yaml.readthedocs.io/en/latest/" }


### PR DESCRIPTION
- Bump minimal Python from 3.8 to 3.10
- Update tests to use 3.10 and 3.12
- Update minimal Pydantic to `~=1.10.22` and test the current latest version of Pydantic (as well as 1st version supporting 3.12).
- Update minimal Ruamel to `>=0.17.0,<0.19` and test with 0.17 and 0.18
- Update ReadTheDocs config to properly build docs.