### PR TITLE
Feature: Save Pydantic model docstrings and field descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,11 @@ assert m1 == m2
 m3 = parse_yaml_raw_as(MyModel, jsn)
 assert m1 == m3
 
+# You can also auto-generate comments in YAML from the model docstrings and field descriptions
+print(to_yaml_str(m1, add_comments=True))
 ```
+
+See [comment generation docs](docs/comments.md) for more info.
 
 With Pydantic v2, you can also dump dataclasses:
 
@@ -126,4 +130,4 @@ However, this will be availble only for `pydantic<2`.
 ### Versioned Models
 
 This functionality has been removed, as it's questionably useful for most users.
-There is an [example in the docs](versioned.md) that's available.
+There is an [example in the docs](docs/versioned.md) that's available.

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,0 +1,99 @@
+# Dumping Comments
+
+Writing YAML models with comments has been a hotly-requested feature,
+as comments are one of the (many) features why YAML is nicer than JSON for human-facing things.
+
+## Adding Descriptions
+
+The preferred way is to use `typing.Annotated` and `pydantic.Field` for fields, and just docstrings for models:
+
+```python
+from typing import Annotated
+
+from pydantic import BaseModel, Field
+
+class MyModel(BaseModel):
+    """My custom model."""  # This will become the header!
+
+    c: Annotated[float, Field(description="See three?")] = 3  # description will become a comment
+
+```
+
+or via configuring the `model_config` to use docstrings as descriptions:
+
+```python
+
+class MyModel(BaseModel):
+    """My custom model.""" # This will become the header!
+
+    model_config = ConfigDict(use_attribute_docstrings=True)  # you can set this in your own BaseModel
+
+    c: float = 3
+    """See three?"""  # docstring will become description and comment; additional editor benefit!
+```
+
+Both of these options will work to create:
+
+```python
+from pydantic_yaml import to_yaml_str
+
+mdl = MyModel(c=3.14)
+print(to_yaml_str(mdl, add_comments=True))
+```
+
+with output:
+
+```yaml
+# My custom model.
+c: 3.14  # See three?
+```
+
+See the Pydantic docs for more options how to add descriptions in
+[Pydantic v2](https://docs.pydantic.dev/latest/concepts/fields/#customizing-json-schema)
+and in [Pydantic v1](https://docs.pydantic.dev/1.10/usage/schema/).
+
+## More Options
+
+Note that you can also export just the headers:
+
+```python
+print(to_yaml_str(mdl, add_comments='models-only'))
+```
+
+```yaml
+# My custom model.
+c: 3.14
+```
+
+or just the fields:
+
+```python
+print(to_yaml_str(mdl, add_comments='fields-only'))
+```
+
+```yaml
+c: 3.14  # See three?
+```
+
+## Dumping Example Classes
+
+If you just want to create example YAML files, you have several main options:
+
+1. Create a fully-fledged example showing options. This might be time-consuming, but is probably best for your users.
+2. "Construct" the example models using [`model_construct()` for v2](https://docs.pydantic.dev/latest/api/base_model/#pydantic.BaseModel.model_construct)  (just [`construct()` for v1](https://docs.pydantic.dev/1.10/usage/models/#creating-models-without-validation)) and use `None` for fields that are not optional but still need to be added.
+   - Your docstrings and descriptions will still be used, so might be a bit confusing to users. Consider `add_comments="fields-only"`.
+3. Create a parallel 'documentation model' where you instruct users in your docstrings/descriptions (rather than document code) and have some examples (or None) as default values.
+   - This is the most time-consuming, but gives you the most control.
+
+Example of option 2:
+
+```python
+ex = MyModel.model_construct(c=None)
+print(to_yaml_str(ex, add_comments="fields-only"))
+```
+
+gives
+
+```yaml
+print(to_yaml_str(ex, add_comments=True))
+```

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -1,7 +1,8 @@
 # Dumping Comments
 
-Writing YAML models with comments has been a hotly-requested feature,
-as comments are one of the (many) features why YAML is nicer than JSON for human-facing things.
+Writing YAML models with comments has been
+[a hotly-requested feature](https://github.com/NowanIlfideme/pydantic-yaml/issues/83),
+as comments are one of the (many) features why YAML is nicer than JSON for human-facing configuration.
 
 ## Adding Descriptions
 

--- a/docs/comments.md
+++ b/docs/comments.md
@@ -95,5 +95,5 @@ print(to_yaml_str(ex, add_comments="fields-only"))
 gives
 
 ```yaml
-print(to_yaml_str(ex, add_comments=True))
+c:  # See three?
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -55,7 +55,11 @@ assert m1 == m2
 m3 = parse_yaml_raw_as(MyModel, jsn)
 assert m1 == m3
 
+# You can also auto-generate comments in YAML from the model docstrings and field descriptions
+print(to_yaml_str(m1, add_comments=True))
 ```
+
+See [comment generation docs](comments.md) for more info.
 
 With Pydantic v2, you can also dump dataclasses:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ use_directory_urls: false
 nav:
   - Overview: index.md
   - Install: installing.md
+  - Comments: comments.md
   - Deprecated:
       - Versioned Models: versioned.md
 

--- a/src/pydantic_yaml/_internals/comments.py
+++ b/src/pydantic_yaml/_internals/comments.py
@@ -1,0 +1,15 @@
+"""Comments options."""
+
+from textwrap import dedent
+from typing import Literal
+
+
+CommentsOptions = Literal["fields-only", "models-only"] | bool
+
+
+def as_yaml_comment(value: str | None) -> str | None:
+    """Convert a value (e.g. docstring) into a YAML comment."""
+    if value is None:
+        return None
+    lines = dedent(value.lstrip("\n").rstrip()).split("\n")
+    return "\n".join([f"# {v}".strip() for v in lines])

--- a/src/pydantic_yaml/_internals/v1.py
+++ b/src/pydantic_yaml/_internals/v1.py
@@ -3,17 +3,22 @@
 # mypy: ignore-errors
 
 import json
+import warnings
+from collections.abc import Mapping, Sequence
 from io import StringIO, BytesIO, IOBase
 from pathlib import Path
 from typing import Any, TypeVar
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
-from ruamel.yaml import YAML
+from ruamel.yaml import CommentedMap, CommentedSeq, YAML
 
 if PYDANTIC_VERSION > "2":
     raise ImportError("This module can only be imported in Pydantic v1.")
 
 from pydantic import BaseModel, parse_obj_as
+from pydantic.fields import FieldInfo
+
+from .comments import CommentsOptions
 
 T = TypeVar("T", bound=BaseModel)
 
@@ -22,7 +27,69 @@ def _chk_model(model: Any) -> BaseModel:
     """Ensure the model passed is a Pydantic model."""
     if isinstance(model, BaseModel):
         return model
-    raise TypeError("We can currently only write `pydantic.BaseModel`, " f"but recieved: {model!r}")
+    raise TypeError(
+        "We can currently only write `pydantic.BaseModel`, " f"but recieved: {model!r}"
+    )
+
+
+def _get_doc(obj: BaseModel | FieldInfo | Any, opts: CommentsOptions) -> str | None:
+    """Get documentation for the model or field, taking options into account."""
+    if isinstance(obj, BaseModel):
+        if opts in (True, "models-only"):
+            return getattr(obj, "__doc__", None)
+        return None
+    elif isinstance(obj, FieldInfo):
+        if opts in (True, "fields-only"):
+            return obj.description
+        return None
+    return None
+
+
+def _add_descriptions(
+    ystruct: CommentedMap | CommentedSeq,  # or other stuff...
+    obj: BaseModel | Mapping | Sequence | Any,
+    opts: CommentsOptions,
+) -> None:
+    """Add descriptions from the object to the yaml struct (modifying it).
+
+    This will fail if `ystruct` and `obj` don't have the same structure.
+    """
+    # Add top-level comment
+    top_lvl = _get_doc(obj, opts=opts)
+    if top_lvl is not None:
+        try:
+            indent = ystruct.lc.col  # type: ignore  # HACK
+        except Exception:
+            indent = 0
+        ystruct.yaml_set_start_comment(top_lvl, indent=indent)
+
+    if obj.__custom_root_type__:
+        # RootModel should probably work
+        obj = obj.__dict__["__root__"]
+
+    if isinstance(obj, BaseModel):
+        # Add field information
+        flds: dict[str, FieldInfo] = obj.__fields__
+
+        for fld_name, fld_info in flds.items():
+            if fld_name in ystruct.keys():
+                # Add field description (if any/allowed)
+                fld_desc = _get_doc(fld_info, opts=opts)
+                if fld_desc is not None:
+                    ystruct.yaml_add_eol_comment(fld_desc, key=fld_name)
+
+                # Recurse into fields
+                fld_obj = getattr(obj, fld_name, None)
+                if isinstance(fld_obj, BaseModel | Sequence | Mapping):
+                    _add_descriptions(ystruct[fld_name], fld_obj, opts=opts)
+                # otherwise - no additional descriptions
+    elif isinstance(obj, Sequence) and isinstance(ystruct, CommentedSeq):
+        # Recurse into parts of the sequence; needed in cases of `list[dict[str, MyModel]]` and such
+        for i, sub_obj in enumerate(obj):
+            _add_descriptions(ystruct[i], sub_obj, opts=opts)
+    elif isinstance(obj, Mapping) and isinstance(ystruct, CommentedMap):
+        for key, sub_obj in obj.items():
+            _add_descriptions(ystruct[key], sub_obj, opts=opts)
 
 
 def parse_yaml_raw_as(model_type: type[T], raw: str | bytes | IOBase) -> T:
@@ -78,6 +145,7 @@ def _write_yaml_model(
     stream: IOBase,
     model: BaseModel,
     *,
+    add_comments: CommentsOptions = False,
     default_flow_style: bool | None = None,
     indent: int | None = None,
     map_indent: int | None = None,
@@ -96,6 +164,8 @@ def _write_yaml_model(
         The stream to write to.
     model : BaseModel
         The model to write.
+    add_comments : False or True or "fields-only" or "models-only"
+        Whether to add comments to the output YAML using fields and/or model descriptions.
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).
         https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
@@ -118,19 +188,41 @@ def _write_yaml_model(
     elif isinstance(custom_yaml_writer, YAML):
         writer = custom_yaml_writer
     else:
-        raise TypeError(f"Please pass a YAML instance or subclass. Got {custom_yaml_writer!r}")
+        raise TypeError(
+            f"Please pass a YAML instance or subclass. Got {custom_yaml_writer!r}"
+        )
     # Set options
     if default_flow_style is not None:
         writer.default_flow_style = default_flow_style
     writer.indent(mapping=indent, sequence=indent, offset=indent)
-    writer.indent(mapping=map_indent, sequence=sequence_indent, offset=sequence_dash_offset)
+    writer.indent(
+        mapping=map_indent, sequence=sequence_indent, offset=sequence_dash_offset
+    )
     # TODO: Configure writer further?
-    writer.dump(val, stream)
+    if add_comments is False:
+        writer.dump(val, stream)
+    elif add_comments in (True, "fields-only", "models-only"):
+        # We need to roundtrip!
+        temp_stream = StringIO()
+        writer.dump(val, temp_stream)
+        rt_yaml = YAML(typ="rt", pure=True)
+        ystruct = rt_yaml.load(temp_stream.getvalue())
+        if isinstance(ystruct, CommentedMap | CommentedSeq):
+            _add_descriptions(ystruct, obj=model, opts=add_comments)
+            rt_yaml.dump(ystruct, stream)
+        else:
+            # Don't know what to do with this; just write the original value
+            warnings.warn(
+                "Failed to add comments to model; is not a map or sequence.",
+                category=UserWarning,
+            )
+            writer.dump(val, stream)
 
 
 def to_yaml_str(
     model: BaseModel,
     *,
+    add_comments: CommentsOptions = False,
     default_flow_style: bool | None = False,
     indent: int | None = None,
     map_indent: int | None = None,
@@ -145,6 +237,8 @@ def to_yaml_str(
     ----------
     model : BaseModel
         The model to convert.
+    add_comments : False or True or "fields-only" or "models-only"
+        Whether to add comments to the output YAML using fields and/or model descriptions.s
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).
         https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
@@ -168,6 +262,7 @@ def to_yaml_str(
     _write_yaml_model(
         stream,
         model,
+        add_comments=add_comments,
         default_flow_style=default_flow_style,
         indent=indent,
         map_indent=map_indent,
@@ -184,6 +279,7 @@ def to_yaml_file(
     file: Path | str | IOBase,
     model: BaseModel,
     *,
+    add_comments: CommentsOptions = False,
     default_flow_style: bool | None = False,
     indent: int | None = None,
     map_indent: int | None = None,
@@ -200,6 +296,8 @@ def to_yaml_file(
         The file path or stream to write to.
     model : BaseModel
         The model to write.
+    add_comments : False or True or "fields-only" or "models-only"
+        Whether to add comments to the output YAML using fields and/or model descriptions.
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).
         https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
@@ -220,6 +318,7 @@ def to_yaml_file(
     """
     model = _chk_model(model)
     write_kwargs = dict(
+        add_comments=add_comments,
         default_flow_style=default_flow_style,
         indent=indent,
         map_indent=map_indent,

--- a/src/pydantic_yaml/_internals/v2.py
+++ b/src/pydantic_yaml/_internals/v2.py
@@ -11,20 +11,26 @@ Roundtrip comments with ruamel.yaml
 # mypy: ignore-errors
 
 import json
+import warnings
+from collections.abc import Mapping, Sequence
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from typing import Any, TypeVar
 from typing_extensions import Literal  # noqa
 
 from pydantic.version import VERSION as PYDANTIC_VERSION
-from ruamel.yaml import YAML
+from ruamel.yaml import CommentedMap, CommentedSeq, YAML
 
 if (PYDANTIC_VERSION < "2") or (PYDANTIC_VERSION > "3"):
     raise ImportError("This module can only be imported in Pydantic v2.")
 
-from pydantic import BaseModel, TypeAdapter
+from pydantic import BaseModel, RootModel, TypeAdapter
 from pydantic.v1 import BaseModel as BaseModelV1
 from pydantic.v1 import parse_obj_as
+from pydantic.v1.fields import FieldInfo as FieldInfoV1
+from pydantic.fields import FieldInfo
+
+from .comments import CommentsOptions
 
 T = TypeVar("T", bound=BaseModel | BaseModelV1)
 
@@ -41,10 +47,84 @@ def _chk_model(model: Any) -> tuple[BaseModel | BaseModelV1, Literal[1, 2]]:
     )
 
 
+def _get_doc(
+    obj: BaseModel | BaseModelV1 | FieldInfo | FieldInfoV1 | Any, opts: CommentsOptions
+) -> str | None:
+    """Get documentation for the model or field, taking options into account."""
+    if isinstance(obj, BaseModel | BaseModelV1):
+        if opts in (True, "models-only"):
+            return getattr(obj, "__doc__", None)
+        return None
+    elif isinstance(obj, FieldInfo | FieldInfoV1):
+        if opts in (True, "fields-only"):
+            return obj.description
+        return None
+    return None
+
+
+def _add_descriptions(
+    ystruct: CommentedMap | CommentedSeq,  # or other stuff...
+    obj: BaseModel | BaseModelV1 | Mapping | Sequence | Any,
+    opts: CommentsOptions,
+) -> None:
+    """Add descriptions from the object to the yaml struct (modifying it).
+
+    This will fail if `ystruct` and `obj` don't have the same structure.
+    """
+    # Add top-level comment
+    top_lvl = _get_doc(obj, opts=opts)
+    if top_lvl is not None:
+        try:
+            indent = ystruct.lc.col  # type: ignore  # HACK
+        except Exception:
+            indent = 0
+        ystruct.yaml_set_start_comment(top_lvl, indent=indent)
+
+    if isinstance(obj, BaseModel):
+        if obj.__pydantic_root_model__:
+            # RootModel should probably work
+            assert isinstance(obj, RootModel), "Model incorrectly set as RootModel."
+            obj = obj.root
+    elif isinstance(obj, BaseModelV1):
+        if obj.__custom_root_type__:
+            # RootModel should probably work
+            obj = obj.__dict__["__root__"]
+
+    if isinstance(obj, BaseModel | BaseModelV1):
+        # Add field information
+        flds: dict[str, FieldInfo] | dict[str, FieldInfoV1]
+
+        if isinstance(obj, BaseModel):
+            flds = obj.model_fields
+        elif isinstance(obj, BaseModelV1):
+            flds = obj.__fields__
+
+        for fld_name, fld_info in flds.items():
+            if fld_name in ystruct.keys():
+                # Add field description (if any/allowed)
+                fld_desc = _get_doc(fld_info, opts=opts)
+                if fld_desc is not None:
+                    ystruct.yaml_add_eol_comment(fld_desc, key=fld_name)
+
+                # Recurse into fields
+                fld_obj = getattr(obj, fld_name, None)
+                if isinstance(fld_obj, BaseModel | BaseModelV1 | Sequence | Mapping):
+                    _add_descriptions(ystruct[fld_name], fld_obj, opts=opts)
+                # otherwise - no additional descriptions
+    elif isinstance(obj, Sequence) and isinstance(ystruct, CommentedSeq):
+        # Recurse into parts of the sequence; needed in cases of `list[dict[str, MyModel]]` and such
+        for i, sub_obj in enumerate(obj):
+            _add_descriptions(ystruct[i], sub_obj, opts=opts)
+    elif isinstance(obj, Mapping) and isinstance(ystruct, CommentedMap):
+        for key, sub_obj in obj.items():
+            _add_descriptions(ystruct[key], sub_obj, opts=opts)
+
+
 def _write_yaml_model(
     stream: IOBase,
     model: BaseModel | BaseModelV1,
     *,
+    add_comments: CommentsOptions = False,
     default_flow_style: bool | None = None,
     indent: int | None = None,
     map_indent: int | None = None,
@@ -63,6 +143,8 @@ def _write_yaml_model(
         The stream to write to.
     model : BaseModel
         The model to write.
+    add_comments : False or True or "fields-only" or "models-only"
+        Whether to add comments to the output YAML using fields and/or model descriptions.
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).
         https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
@@ -74,7 +156,7 @@ def _write_yaml_model(
         An instance of ruamel.yaml.YAML (or a subclass) to use as the writer.
         The above options will be set on it, if given.
     json_kwargs : Any
-        Keyword arguments to pass `model.json()`.
+        Keyword arguments to pass `model.model_dump_json()`.
     """
     model, vers = _chk_model(model)
     if vers == 1:
@@ -88,19 +170,41 @@ def _write_yaml_model(
     elif isinstance(custom_yaml_writer, YAML):
         writer = custom_yaml_writer
     else:
-        raise TypeError(f"Please pass a YAML instance or subclass. Got {custom_yaml_writer!r}")
+        raise TypeError(
+            f"Please pass a YAML instance or subclass. Got {custom_yaml_writer!r}"
+        )
     # Set options
     if default_flow_style is not None:
         writer.default_flow_style = default_flow_style
     writer.indent(mapping=indent, sequence=indent, offset=indent)
-    writer.indent(mapping=map_indent, sequence=sequence_indent, offset=sequence_dash_offset)
+    writer.indent(
+        mapping=map_indent, sequence=sequence_indent, offset=sequence_dash_offset
+    )
     # TODO: Configure writer further?
-    writer.dump(val, stream)
+    if add_comments is False:
+        writer.dump(val, stream)
+    elif add_comments in (True, "fields-only", "models-only"):
+        # We need to roundtrip!
+        temp_stream = StringIO()
+        writer.dump(val, temp_stream)
+        rt_yaml = YAML(typ="rt", pure=True)
+        ystruct = rt_yaml.load(temp_stream.getvalue())
+        if isinstance(ystruct, CommentedMap | CommentedSeq):
+            _add_descriptions(ystruct, obj=model, opts=add_comments)
+            rt_yaml.dump(ystruct, stream)
+        else:
+            # Don't know what to do with this; just write the original value
+            warnings.warn(
+                "Failed to add comments to model; is not a map or sequence.",
+                category=UserWarning,
+            )
+            writer.dump(val, stream)
 
 
 def to_yaml_str(
     model: BaseModel | BaseModelV1,
     *,
+    add_comments: CommentsOptions = False,
     default_flow_style: bool | None = False,
     indent: int | None = None,
     map_indent: int | None = None,
@@ -115,6 +219,8 @@ def to_yaml_str(
     ----------
     model : BaseModel
         The model to convert.
+    add_comments : False or "all" or "fields-only" or "models-only"
+        Whether to add comments to the output YAML using fields and/or model descriptions.
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).
         https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
@@ -126,7 +232,7 @@ def to_yaml_str(
         An instance of ruamel.yaml.YAML (or a subclass) to use as the writer.
         The above options will be set on it, if given.
     json_kwargs : Any
-        Keyword arguments to pass `model.json()`.
+        Keyword arguments to pass `model.model_dump_json()`.
 
     Notes
     -----
@@ -138,6 +244,7 @@ def to_yaml_str(
     _write_yaml_model(
         stream,
         model,
+        add_comments=add_comments,
         default_flow_style=default_flow_style,
         indent=indent,
         map_indent=map_indent,
@@ -154,6 +261,7 @@ def to_yaml_file(
     file: Path | str | IOBase,
     model: BaseModel | BaseModelV1,
     *,
+    add_comments: CommentsOptions = False,
     default_flow_style: bool | None = False,
     indent: int | None = None,
     map_indent: int | None = None,
@@ -170,6 +278,8 @@ def to_yaml_file(
         The file path or stream to write to.
     model : BaseModel
         The model to write.
+    add_comments : False or "all" or "fields-only" or "models-only"
+        Whether to add comments to the output YAML using fields and/or model descriptions.
     default_flow_style : bool
         Whether to use "flow style" (more human-readable).
         https://yaml.readthedocs.io/en/latest/detail.html?highlight=default_flow_style#indentation-of-block-sequences
@@ -181,7 +291,7 @@ def to_yaml_file(
         An instance of ruamel.yaml.YAML (or a subclass) to use as the writer.
         The above options will be set on it, if given.
     json_kwargs : Any
-        Keyword arguments to pass `model.json()`.
+        Keyword arguments to pass `model.model_dump_json()`.
 
     Notes
     -----
@@ -190,6 +300,7 @@ def to_yaml_file(
     """
     model, _ = _chk_model(model)
     write_kwargs = dict(
+        add_comments=add_comments,
         default_flow_style=default_flow_style,
         indent=indent,
         map_indent=map_indent,

--- a/src/pydantic_yaml/examples/__init__.py
+++ b/src/pydantic_yaml/examples/__init__.py
@@ -1,0 +1,1 @@
+"""Models to be used in examples."""

--- a/src/pydantic_yaml/examples/base_models.py
+++ b/src/pydantic_yaml/examples/base_models.py
@@ -23,6 +23,7 @@ import pydantic
 from .common import MyIntEnum, MyStrEnum
 
 root = Path(__file__).resolve().parent / "base_models"
+commented = Path(__file__).resolve().parent / "commented"
 
 if pydantic.version.VERSION < "2":
     from .v1.base_models import (

--- a/src/pydantic_yaml/examples/commented/false/uses_refs.yaml
+++ b/src/pydantic_yaml/examples/commented/false/uses_refs.yaml
@@ -1,0 +1,6 @@
+bill_to:
+  family: Dumars
+  given: Chris
+ship_to:
+  family: Dumars
+  given: Chris

--- a/src/pydantic_yaml/examples/commented/fields/uses_refs.yaml
+++ b/src/pydantic_yaml/examples/commented/fields/uses_refs.yaml
@@ -1,0 +1,6 @@
+bill_to:  # Billing information
+  family: Dumars  # Family name(s), often called 'last name' in English.
+  given: Chris  # Given name(s), often called 'first name' in English.
+ship_to: # Shipping information (no address)
+  family: Dumars  # Family name(s), often called 'last name' in English.
+  given: Chris  # Given name(s), often called 'first name' in English.

--- a/src/pydantic_yaml/examples/commented/models/uses_refs.yaml
+++ b/src/pydantic_yaml/examples/commented/models/uses_refs.yaml
@@ -1,0 +1,9 @@
+# Example for the reference data.
+bill_to:
+  # First/last names.
+  family: Dumars
+  given: Chris
+ship_to:
+  # First/last names.
+  family: Dumars
+  given: Chris

--- a/src/pydantic_yaml/examples/commented/true/uses_refs.yaml
+++ b/src/pydantic_yaml/examples/commented/true/uses_refs.yaml
@@ -1,0 +1,7 @@
+# Example for the reference data.
+bill_to:  # Billing information
+  family: Dumars  # Family name(s), often called 'last name' in English.
+  given: Chris  # Given name(s), often called 'first name' in English.
+ship_to: # Shipping information (no address)
+  family: Dumars  # Family name(s), often called 'last name' in English.
+  given: Chris  # Given name(s), often called 'first name' in English.

--- a/src/pydantic_yaml/examples/v1/base_models.py
+++ b/src/pydantic_yaml/examples/v1/base_models.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import BaseModel, Field
 from pydantic.types import SecretBytes, SecretStr
@@ -72,15 +72,15 @@ class HasEnums(BaseModel):
 class _Name(BaseModel):
     """First/last names."""
 
-    given: str
-    family: str
+    given: str = Field(description="Given name(s), often called 'first name' in English.")
+    family: Annotated[str, Field(description="Family name(s), often called 'last name' in English.")]
 
 
 class UsesRefs(BaseModel):
     """Example for the reference data."""
 
-    bill_to: _Name = Field(alias="bill-to")
-    ship_to: _Name = Field(alias="ship-to")
+    bill_to: _Name = Field(alias="bill-to", description="Billing information")
+    ship_to: _Name = Field(alias="ship-to", description="Shipping information (no address)")
 
     class Config:
         """Pydantic configuration class."""

--- a/src/pydantic_yaml/examples/v2/base_models.py
+++ b/src/pydantic_yaml/examples/v2/base_models.py
@@ -2,7 +2,7 @@
 
 # mypy: ignore-errors
 
-from typing import Optional
+from typing import Annotated, Optional
 
 from pydantic import (
     BaseModel,
@@ -81,15 +81,15 @@ class HasEnums(BaseModel):
 class _Name(BaseModel):  # type: ignore[no-redef]
     """First/last names."""
 
-    given: str
-    family: str
+    given: str = Field(description="Given name(s), often called 'first name' in English.")
+    family: Annotated[str, Field(description="Family name(s), often called 'last name' in English.")]
 
 
 class UsesRefs(BaseModel):  # type: ignore[no-redef]
     """Example for the reference data."""
 
-    bill_to: _Name = Field(alias="bill-to")
-    ship_to: _Name = Field(alias="ship-to")
+    bill_to: _Name = Field(alias="bill-to", description="Billing information")
+    ship_to: _Name = Field(alias="ship-to", description="Shipping information (no address)")
 
     # Pydantic config
     model_config = ConfigDict(populate_by_name=True)

--- a/src/test/test_comment_writing.py
+++ b/src/test/test_comment_writing.py
@@ -1,0 +1,35 @@
+"""Test the comment functionality."""
+
+from pathlib import Path
+
+import pytest
+from pydantic import BaseModel
+
+from pydantic_yaml import parse_yaml_file_as, to_yaml_str
+from pydantic_yaml._internals.comments import CommentsOptions
+from pydantic_yaml.examples.base_models import UsesRefs, commented, root
+
+sub_ps: dict[CommentsOptions, Path] = {
+    False: commented / "false",
+    True: commented / "true",
+    "fields-only": commented / "fields",
+    "models-only": commented / "models",
+}
+
+
+@pytest.mark.parametrize(
+    ["model_type", "fn"],
+    [
+        (UsesRefs, "uses_refs.yaml"),
+    ],
+)
+def test_load_rt_simple_files(model_type: type[BaseModel], fn: str):
+    """Test simple file loading and roundtripping."""
+    # Load usual file
+    in_file = root / fn
+    obj = parse_yaml_file_as(model_type, in_file)
+    # Compare
+    for add_c, sub_p in sub_ps.items():
+        got_i = to_yaml_str(obj, add_comments=add_c)
+        expected_i = (commented / sub_p / fn).read_text()
+        assert got_i == expected_i, "Comments not as expected."

--- a/tmp_comment_examples.py
+++ b/tmp_comment_examples.py
@@ -3,6 +3,7 @@
 from typing import Annotated
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
+
 from pydantic_yaml import to_yaml_str
 
 
@@ -48,3 +49,8 @@ class ModelR(RootModel[list[ModelA]]):
 
 mr = ModelR(root=[ma])
 print(to_yaml_str(mr, add_comments=True))
+
+
+# Try constructed model
+ma_bad = ModelA.model_construct(a=None, b=None, c=None)
+print(to_yaml_str(ma_bad, add_comments=True))

--- a/tmp_comment_examples.py
+++ b/tmp_comment_examples.py
@@ -1,0 +1,50 @@
+"""Test stuff."""
+
+from typing import Annotated
+
+from pydantic import BaseModel, ConfigDict, Field, RootModel
+from pydantic_yaml import to_yaml_str
+
+
+class ModelA(BaseModel):
+    """My model A."""
+
+    a: int = 1
+    b: str = "b"
+    c: Annotated[float, Field(description="See description...")] = 3
+
+
+ma = ModelA()
+print(to_yaml_str(ma, add_comments=True))
+
+
+class ModelB(BaseModel):
+    """My model A."""
+
+    model_config = ConfigDict(use_attribute_docstrings=True)
+
+    sub1: ModelA
+    """Sub-model."""
+    sub2: list[ModelA]
+    """Sub-models as a list."""
+    sub3: dict[str, ModelA]
+    """Sub-models as a dict."""
+    sub4: list[dict[str, ModelA]]
+    """Even more crazy nested dict."""
+
+
+mb = ModelB(
+    sub1=ma,
+    sub2=[ma],
+    sub3={"ma": ma},
+    sub4=[{"ma": ma}, {"mo": ma}, {"mia": ma}],
+)
+print(to_yaml_str(mb, add_comments=True))
+
+
+class ModelR(RootModel[list[ModelA]]):
+    """List of model A."""
+
+
+mr = ModelR(root=[ma])
+print(to_yaml_str(mr, add_comments=True))


### PR DESCRIPTION
Implementation of #83 

Based on code from [pydantic-example](https://github.com/bneijt/pydantic-examples/blob/main/src/pydantic_examples/yaml.py) (with [permission](https://github.com/bneijt/pydantic-examples/issues/10#issuecomment-2906975325)) and some hacking around the `ruamel.yaml` library (the lack of typing or implicit `None` values make it really, really hard to work with besides the public interfaces).

Still WIP - no tests.