### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,8 @@ jobs:
   ci-check:
     name: "Pre-publishing CI Checks"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: true # we want CI to immediately fail for releases
       matrix:

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   gha-uv-version: "0.11.5"
 


### PR DESCRIPTION
Potential fix for [https://github.com/NowanIlfideme/pydantic-yaml/security/code-scanning/2](https://github.com/NowanIlfideme/pydantic-yaml/security/code-scanning/2)

Add an explicit `permissions` block at the workflow root so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the best minimal fix is:

- In `.github/workflows/python-testing.yml`, add:
  - `permissions:`
  - `  contents: read`

Place it near the top-level keys (e.g., after `on:` and before `env:`), preserving existing behavior while constraining token scope. No imports/methods/dependencies are needed since this is YAML config only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
