### PR TITLE
Fix code scanning alert: minimize GH_TOKEN permissions

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -18,6 +18,8 @@ jobs:
   ci-check:
     name: "Pre-publishing CI Checks"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: true # we want CI to immediately fail for releases
       matrix:

--- a/.github/workflows/python-testing.yml
+++ b/.github/workflows/python-testing.yml
@@ -11,6 +11,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 env:
   gha-uv-version: "0.11.5"
 


### PR DESCRIPTION
Minimize GitHub token permissions on CI workflows.